### PR TITLE
Hide agent alerts by default

### DIFF
--- a/mission-control/src/components/stages/ThinkStage.tsx
+++ b/mission-control/src/components/stages/ThinkStage.tsx
@@ -64,7 +64,7 @@ export const ThinkStage: React.FC<ThinkStageProps> = ({
   error,
   onFilterChange,
 }) => {
-  const [filter, setFilter] = useState<FilterType>('all')
+  const [filter, setFilter] = useState<FilterType>('ideas')
 
   // Notify parent when filter changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Default the Think stage feed to the Ideas filter so agent alerts are hidden on first load.
- Keep the All and Alerts filters available for manually viewing alerts.

## Validation
- `git diff --check`
- `npm run typecheck` attempted, but the existing project-wide TypeScript errors unrelated to this change still fail the command.
- `npx eslint src/components/stages/ThinkStage.tsx --ext ts,tsx` attempted, but this checkout has no ESLint config file.