### PR TITLE
Hide agent alerts by default

### DIFF
--- a/mission-control/src/components/stages/ThinkStage.tsx
+++ b/mission-control/src/components/stages/ThinkStage.tsx
@@ -64,7 +64,7 @@ export const ThinkStage: React.FC<ThinkStageProps> = ({
   error,
   onFilterChange,
 }) => {
-  const [filter, setFilter] = useState<FilterType>('all')
+  const [filter, setFilter] = useState<FilterType>('ideas')
 
   // Notify parent when filter changes
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Default the Think stage feed to the Ideas filter so agent/non-idea alerts are hidden on initial load.
- Keep the existing Alerts and All filters available for viewing alerts explicitly.

## Validation
- `git diff --check`
- `npm run typecheck` currently fails on unrelated existing issues: missing `@/components/ui/*` modules, missing `react-resizable-panels`, ADI type mismatches, and ValidateStage date typing errors.